### PR TITLE
expose JDB for hacking

### DIFF
--- a/jbase.js
+++ b/jbase.js
@@ -13,7 +13,8 @@ module.exports = {
     {
         // The constructor of JDB handles the create or load logic.
         return new JDB(name, options);
-    }
+    },
+    JDB: JDB
 }; // end exports
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I'd like to get at `JDB.prototype`, which would allow me to provide a "null" database for testing or simply to extend `JDB` itself.
