### PR TITLE
Support for requesting a database instance multiple time.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -295,6 +295,15 @@ var db = jbase.db('some_db', { writeToDisk: false });
 This will look for a file named `"./some_db.json"`. (If your database lives somewhere else, you can pass the `rootPath`
 option in to the `db` call.)
 
+##### New in 1.0.0
+
+You can now request the same database multiple times, and get back the same instance. This allows you to request the
+database by name in different places in your code, and not worry about the two database instance fighting with each
+other. (The previous behavior was clearly broken, and resulted in very strange issues.)
+
+_Note_: When you request a database any other time than the first, the options are ignored. There is currently no way to
+change a database's options at run time.
+
 ##### Options
 
 The options supported by the `db` call are:

--- a/examples/horrible_model_example.js
+++ b/examples/horrible_model_example.js
@@ -39,7 +39,7 @@ jbase.Promise.all([
     .then(function()
     {
         // We've finished adding values, so print out the database:
-        console.log('\n[Step 1] db.values:\n%s', pprint(horrible.$$db.values));
+        console.log('\n[Step 1] db.values:\n%s', pprint(jbase.db('characters').values));
 
         // Update hammer's values
         hammer.nemeses.push(horrible.id);
@@ -58,7 +58,7 @@ jbase.Promise.all([
     .then(function()
     {
         // We've finished updating values, so print out the database:
-        console.log('\n[Step 2] db.values:\n%s', pprint(horrible.$$db.values));
+        console.log('\n[Step 2] db.values:\n%s', pprint(jbase.db('characters').values));
 
         // Filter for just the people who love Penny
         return Character.filter({ loveInterest: penny.id })

--- a/jbase.js
+++ b/jbase.js
@@ -12,11 +12,20 @@ var errors = require('./lib/errors');
 
 //----------------------------------------------------------------------------------------------------------------------
 
+var dbInstances = {};
+
 module.exports = {
     db: function(name, options)
     {
-        // The constructor of JDB handles the create or load logic.
-        return new JDB(name, options);
+        var db = dbInstances[name];
+
+        if(!db)
+        {
+            db = new JDB(name, options);
+            dbInstances[name] = db;
+        } // end if
+
+        return db;
     },
     defineModel: models.defineModel,
     JDB: JDB,

--- a/lib/jdb.js
+++ b/lib/jdb.js
@@ -20,6 +20,9 @@ function JDB(name, options)
 {
     EventEmitter.call(this);
 
+    // We disable warnings about max listeners.
+    this.setMaxListeners(0);
+
     this.values = {};
 
     this._name = name;

--- a/lib/models.js
+++ b/lib/models.js
@@ -118,7 +118,7 @@ Model.prototype.sync = function(force)
         .then(function(obj)
         {
             // Only update if we're not dirty, or are forcing a sync.
-            if(!self.$dirty || force)
+            if(obj && !self.$dirty || force)
             {
                 self.$$values = obj;
             } // end if

--- a/tests/jbase.spec.js
+++ b/tests/jbase.spec.js
@@ -31,6 +31,14 @@ describe('JBase', function()
             var db = jbase.db("jbase_test", { writeToDisk: false });
             assert.equal(db.options.writeToDisk, false);
         });
+
+        it('returns the same JDB instance if you request it multiple times', function()
+        {
+            var db = jbase.db("jbase_test", { writeToDisk: false });
+            var db2 = jbase.db("jbase_test");
+
+            assert.equal(db, db2);
+        });
     });
 
     describe('defineModel()', function()

--- a/tests/models.spec.js
+++ b/tests/models.spec.js
@@ -24,15 +24,12 @@ describe('Models', function()
             foo: Number
         }, { writeToDisk: false });
 
-        // Create a throw-away model to get access to the $$db object
-        var throwAway = new TestModel({ name: 'foobar' });
-
         // Populate the database
         jbase.Promise.all([
-                throwAway.$$db.store('test1', { name: 'foobar', admin: false }),
-                throwAway.$$db.store('test2', { name: 'barbaz', admin: true }),
-                throwAway.$$db.store('test3', { name: 'foo 2', admin: false, foo: 3 }),
-                throwAway.$$db.store('test4', { name: 'glipi', admin: true, foo: -1.5 })
+                jbase.db('model_test').store('test1', { name: 'foobar', admin: false }),
+                jbase.db('model_test').store('test2', { name: 'barbaz', admin: true }),
+                jbase.db('model_test').store('test3', { name: 'foo 2', admin: false, foo: 3 }),
+                jbase.db('model_test').store('test4', { name: 'glipi', admin: true, foo: -1.5 })
             ])
             .then(function()
             {
@@ -58,7 +55,7 @@ describe('Models', function()
             test.save().then(function()
             {
                 // Ensure the document is saved in the db correctly.
-                test.$$db.get(test.id).then(function(doc)
+                jbase.db('model_test').get(test.id).then(function(doc)
                 {
                     assert.deepEqual(doc, { id: test.id, name: 'test', admin: false });
                     done();
@@ -74,7 +71,7 @@ describe('Models', function()
                 test.save().then(function()
                 {
                     // Ensure the document is saved in the db correctly.
-                    test.$$db.get(test.id).then(function(doc)
+                    jbase.db('model_test').get(test.id).then(function(doc)
                     {
                         assert.deepEqual(doc, { id: test.id, name: 'foobar', admin: true });
                         done();
@@ -124,7 +121,7 @@ describe('Models', function()
             {
                 assert.equal(test.admin, false);
 
-                test.$$db.merge('test1', { admin: true })
+                jbase.db('model_test').merge('test1', { admin: true })
                     .then(function()
                     {
                         assert.equal(test.admin, true);
@@ -143,7 +140,7 @@ describe('Models', function()
 
                 assert.equal(test.$dirty, true);
 
-                test.$$db.merge('test1', { admin: true })
+                jbase.db('model_test').merge('test1', { admin: true })
                     .then(function()
                     {
                         assert.equal(test.admin, false);
@@ -162,7 +159,7 @@ describe('Models', function()
 
                 assert.equal(test.$dirty, true);
 
-                test.$$db.merge('test1', { admin: true })
+                jbase.db('model_test').merge('test1', { admin: true })
                     .then(function()
                     {
                         assert.equal(test.admin, false);


### PR DESCRIPTION
You can now request the same database multiple times, and get back the same instance. This allows you to request the database by name in different places in your code, and not worry about the two database instance fighting with each other. (The previous behavior was clearly broken, and resulted in very strange issues.)
