### PR TITLE
Allow a default value for db.load

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -314,6 +314,13 @@ db.load('my_key')
         // Work with `val` here
     });
 
+// Get an object asynchronously, with a default value
+db.load('does_not_exist', 'default')
+    .then(function(val)
+    {
+    	// val is equal to 'default'
+    });
+
 // Get an object asynchronously that doesn't exist
 db.load('does_not_exist')
     .then(function(val)

--- a/lib/tdb.js
+++ b/lib/tdb.js
@@ -218,9 +218,9 @@ class TDB extends EventEmitter
         return removed;
     } // end del
 
-    load(key)
+    load(key, defaultVal)
     {
-        return Promise.resolve(this.get(key))
+        return Promise.resolve(this.get(key, defaultVal))
             .tap((val) =>
             {
                 if(val === undefined)

--- a/tests/tdb.spec.js
+++ b/tests/tdb.spec.js
@@ -353,6 +353,15 @@ describe('TDB Instance', () =>
             assert(_.isFunction(promise.then), "`load().then` is not a function!");
         });
 
+        it("`load()` returns a default value when passing in a nonexistent key, and a default value is passed in", () =>
+        {
+            return db.load('does-not-exist', 'default')
+                .then((value) =>
+                {
+                    assert.equal(value, 'default');
+                });
+        });
+
         it("`load()` rejects with a 'DocumentNotFound' error on nonexistent keys", () =>
         {
             return db.load('does-not-exist')


### PR DESCRIPTION
One should be able to provide a default value for `db.load`. This is beneficial when one does not want to handle an exception to get a value - as when `await` as seen in the example below.

```JavaScript
let user = await db.load(userID, null);
if (!user) {
  user = {
  id: userID,
  username,
  bthKey: null
};
await db.save(user);
```